### PR TITLE
Change the type of user_id and record_id to string so UUID keys work!

### DIFF
--- a/db/migrate/20190527035005_create_audit_logs.rb
+++ b/db/migrate/20190527035005_create_audit_logs.rb
@@ -4,8 +4,8 @@ class CreateAuditLogs < ActiveRecord::Migration[5.2]
   def change
     create_table "audit_logs", force: :cascade do |t|
       t.string "action", null: false
-      t.bigint "user_id"
-      t.bigint "record_id"
+      t.string "user_id"
+      t.string "record_id"
       t.string "record_type"
       t.text "payload"
       t.text "request"

--- a/lib/audit-log/model.rb
+++ b/lib/audit-log/model.rb
@@ -7,8 +7,8 @@ module AuditLog
     included do
       self.table_name = AuditLog.config.table_name
 
-      serialize :payload, JSON
-      serialize :request, JSON
+      serialize :payload, coder: JSON
+      serialize :request, coder: JSON
 
       belongs_to :user, class_name: AuditLog.config.user_class, required: false
       belongs_to :record, polymorphic: true, required: false


### PR DESCRIPTION
Current version does not work if your user ids are non-numeric (UUID!). The same with the record id. This little change allows both int and non-int types work.

